### PR TITLE
401 / remove price tooltip

### DIFF
--- a/src/modules/land-works/components/land-works-card-explore-view/index.tsx
+++ b/src/modules/land-works/components/land-works-card-explore-view/index.tsx
@@ -8,7 +8,6 @@ import { useLandsMapTile } from 'modules/land-works/providers/lands-map-tile';
 
 import { AssetEntity } from '../../api';
 import LandCardAvailability from '../land-works-card-availability';
-import { LandsTooltip } from '../lands-tooltip';
 import { ReactComponent as HotIcon } from './assets/hot.svg';
 
 import './index.scss';
@@ -74,17 +73,6 @@ const LandWorksCard: React.FC<Props> = ({ land, onClick, onMouseOver }) => {
           <SmallAmountTooltip symbol="$" amount={land.pricePerMagnitude.usdPrice || ZERO_BIG_NUMBER} />
           <span>/{land.pricePerMagnitude.magnitude}</span>
         </span>
-
-        <LandsTooltip
-          placement="bottomLeft"
-          trigger="hover"
-          text={
-            <>
-              The price for renting this property is {land.humanPricePerSecond.toString(10)}{' '}
-              <Icon name={getTokenIconName(land.paymentToken.symbol)} className="eth-icon" /> per second.
-            </>
-          }
-        />
       </div>
 
       <div className="land-explore-divider"></div>

--- a/src/modules/land-works/components/land-works-card-single-view/index.tsx
+++ b/src/modules/land-works/components/land-works-card-single-view/index.tsx
@@ -294,17 +294,6 @@ const SingleViewLandCard: React.FC<SingleLandProps> = ({
                             amount={asset?.pricePerMagnitude?.usdPrice || ZERO_BIG_NUMBER}
                           />
                           <span className="per-day">/{asset?.pricePerMagnitude?.magnitude}</span>
-                          <LandsTooltip
-                            placement="bottomLeft"
-                            trigger="hover"
-                            text={
-                              <>
-                                The price for renting this property is {asset?.humanPricePerSecond?.toString(10)}{' '}
-                                <Icon name={getTokenIconName(asset?.paymentToken?.symbol || '')} className="eth-icon" />{' '}
-                                per second.
-                              </>
-                            }
-                          />
                         </div>
                       </Grid>
                     </Grid>


### PR DESCRIPTION
**Detailed description**:
Remove price tooltip from property cards
**Which issue(s) this PR fixes**:
Fixes #401 

**Special notes for your reviewer**:

**Checklist**
Remove price tooltip from pages: 
- [x] Explore
- [x] My properties
- [x] Property detail