### PR TITLE
hot fix: improve layout for scene-expert profile

### DIFF
--- a/src/modules/land-works/components/scene-builder-profile/index.tsx
+++ b/src/modules/land-works/components/scene-builder-profile/index.tsx
@@ -26,7 +26,13 @@ const SceneBuilderProfile: FC<ISceneBuilderProfile> = ({ builder }) => {
   const hasEmail = builder?.website !== undefined && builder?.website !== '-';
 
   return (
-    <CardContainer className="scene-builder-card" style={{ minHeight: '578px' }}>
+    <CardContainer
+      className="scene-builder-card"
+      style={{ minHeight: '500px' }}
+      display="flex"
+      flexDirection="column"
+      justifyContent="space-between"
+    >
       <Grid height={185} width="100%" borderRadius="20px" overflow="hidden">
         <Box
           component="img"

--- a/src/modules/land-works/components/scene-builder-profile/scene-builder-details/index.tsx
+++ b/src/modules/land-works/components/scene-builder-profile/scene-builder-details/index.tsx
@@ -22,7 +22,17 @@ const SceneBuilderDetails: FC<ISceneBuilderDetails> = ({ builder }) => {
   };
 
   return (
-    <CardContainer className="scene-builder-card" style={{ padding: '20px 30px', minHeight: '578px', height: '100%' }}>
+    <CardContainer
+      className="scene-builder-card"
+      style={{
+        padding: '20px 30px',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        justifyContent: 'space-evenly',
+      }}
+    >
       <TypographyStyled variant="h4" style={{ textTransform: 'uppercase' }}>
         Builder Details & Services
       </TypographyStyled>

--- a/src/modules/land-works/components/scene-builder-profile/styled.tsx
+++ b/src/modules/land-works/components/scene-builder-profile/styled.tsx
@@ -9,10 +9,6 @@ export const CardContainer = styled(Box)<BoxProps>(() => ({
   backgroundColor: 'var(--theme-card-color)',
   borderRadius: '20px',
   position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
-  justifyContent: 'space-evenly',
 }));
 
 export const StyledImageContainer = styled(Box)<BoxProps>(() => ({


### PR DESCRIPTION
**Detailed description**:

Fix layout of scene builder expert profile. The top margin was not the same for every builder.
