### PR TITLE
[961]: Make only one tooltip appear when user hovers under estate on decentraland map

### DIFF
--- a/src/modules/land-works/components/lands-explore-map/LandTooltip.tsx
+++ b/src/modules/land-works/components/lands-explore-map/LandTooltip.tsx
@@ -28,9 +28,10 @@ interface LandTooltipProps extends Pick<PopperProps, 'container'> {
   land: AssetEntity;
   x: number;
   y: number;
+  open?: boolean;
 }
 
-const LandTooltip = ({ land, x, y, container }: LandTooltipProps) => {
+const LandTooltip = ({ land, open, x, y, container }: LandTooltipProps) => {
   const history = useHistory();
 
   const handlePopperClick = () => {
@@ -42,13 +43,14 @@ const LandTooltip = ({ land, x, y, container }: LandTooltipProps) => {
 
   return (
     <DarkTooltip
-      open
+      open={open}
       arrow
       placement="top"
       title={<LandTooltipContent land={land} />}
       PopperProps={{
         container,
         onClick: handlePopperClick,
+        disablePortal: true,
       }}
     >
       <Box

--- a/src/modules/land-works/views/explore-view/index.tsx
+++ b/src/modules/land-works/views/explore-view/index.tsx
@@ -127,23 +127,27 @@ const ExploreView: React.FC = () => {
     return moreFilters ? filterByMoreFilters(lands, moreFilters, metaverse) : lands;
   }, [lands, moreFilters, metaverse]);
 
-  const setClickedLandId = (x: number | string, y?: number | string | undefined) => {
-    if (x && y) {
-      let landId = `${x},${y}`;
+  const setClickedLandId = useCallback(
+    (x: number | string, y?: number | string | undefined) => {
+      if (x && y) {
+        let landId = `${x},${y}`;
 
-      // Look for the first coordinate for land estate.
-      lands.forEach((land) => {
-        land.decentralandData?.coordinates.forEach((coord, coordIndex) => {
-          if (coordIndex > 0 && coord.id === landId.replace(',', '-')) {
-            landId = `${land.decentralandData?.coordinates[0].x},${land.decentralandData?.coordinates[0].y}`;
-          }
+        // Look for the first coordinate for land estate.
+        lands.forEach((land) => {
+          land.decentralandData?.coordinates.forEach((coord, coordIndex) => {
+            if (coordIndex > 0 && coord.id === landId.replace(',', '-')) {
+              landId = `${land.decentralandData?.coordinates[0].x},${land.decentralandData?.coordinates[0].y}`;
+            }
+          });
         });
-      });
 
-      return setStateClickedLandId(landId);
-    }
-    if (x) setStateClickedLandId(`${x}`);
-  };
+        return setStateClickedLandId(landId);
+      } else {
+        setStateClickedLandId(`${x}`);
+      }
+    },
+    [lands]
+  );
 
   const setPointMapCentre = (lands: CoordinatesLand[]) => {
     if (lands[0]) {
@@ -240,19 +244,30 @@ const ExploreView: React.FC = () => {
     priceParams.maxPrice,
   ]);
 
+  const landsMapTilesValue = useMemo(() => {
+    return {
+      mapTiles,
+      setMapTiles,
+      selectedId,
+      setSelectedId,
+    };
+  }, [mapTiles, setMapTiles, selectedId, setSelectedId]);
+
+  const landsMapTileValue = useMemo(() => {
+    return {
+      clickedLandId,
+      setClickedLandId,
+      selectedTile,
+      setSelectedTile,
+      showCardPreview,
+      setShowCardPreview,
+    };
+  }, [clickedLandId, setClickedLandId, selectedTile, setSelectedTile, showCardPreview, setShowCardPreview]);
+
   return (
     <LandsSearchQueryProvider value={{ searchQuery, setSearchQuery }}>
-      <LandsMapTilesProvider value={{ mapTiles, setMapTiles, selectedId, setSelectedId }}>
-        <LandsMapTileProvider
-          value={{
-            clickedLandId,
-            setClickedLandId,
-            selectedTile,
-            setSelectedTile,
-            showCardPreview,
-            setShowCardPreview,
-          }}
-        >
+      <LandsMapTilesProvider value={landsMapTilesValue}>
+        <LandsMapTileProvider value={landsMapTileValue}>
           <LandsExploreFilters
             handleMoreFilter={setMoreFilters}
             onChangeSortDirection={onChangeFiltersSortDirection}


### PR DESCRIPTION
… hovered lands in fullscreen mode

**Detailed description**:

**Which issue(s) this PR fixes**:
Fixes comment [1340548363](https://github.com/EnterDAO/LandWorks-FE/issues/961#issuecomment-1340548363) for tasks #961

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
